### PR TITLE
Drive synchronized randomness with publicly available datasource

### DIFF
--- a/tulpamancer.lua
+++ b/tulpamancer.lua
@@ -17,7 +17,7 @@ device = midi.connect(1)
 
 function init()
   first_boot = true
-  tulpa_api = 'https://us-central1-tulpamancer.cloudfunctions.net/tulpamancer'
+  tulpa_api = 'https://www.nyse.com/publicdocs/nyse/US_Equities_Volumes.csv'
   tulpa_path = '/home/we/dust/code/tulpamancer/tulpa.txt'
   tulpa_exists = false
   tulpa_binary = ''
@@ -43,9 +43,29 @@ function get_tulpa()
     tulpa_exists = false
     os.execute('curl -s ' .. tulpa_api .. ' > ' .. tulpa_path)
     local file = io.open(tulpa_path, 'rb')
-    tulpa_binary = file:read '*a'
+    local headers = file:read '*line'
+    local data = file:read '*line'
+    local volume = 0
+    local value = 0
+    for value in string.gmatch(data, ",\"([^\"]+)\"") do
+      local x = string.gsub(value, ",", "")
+      volume = volume + tonumber(x)
+    end
     file:close()
+    volume = math.floor(volume)
+    tulpa_binary = number_to_bitstring(volume)
   end
+end
+
+function number_to_bitstring(n, digits)
+  digits = digits or math.max(1, select(2, math.frexp(n)))
+  local t = {}
+  local b = 0
+  for b = digits, 1, -1 do
+      t[b] = math.fmod(n, 2)
+      n = math.floor((n - t[b]) / 2)
+  end
+  return table.concat(t)
 end
 
 function play_tulpa()

--- a/tulpamancer.lua
+++ b/tulpamancer.lua
@@ -45,15 +45,18 @@ function get_tulpa()
     local file = io.open(tulpa_path, 'rb')
     local headers = file:read '*line'
     local data = file:read '*line'
+    file.close()
+    
+    -- parse and sum csv
     local volume = 0
     local value = 0
     for value in string.gmatch(data, ",\"([^\"]+)\"") do
       local x = string.gsub(value, ",", "")
       volume = volume + tonumber(x)
     end
-    file:close()
+
     volume = math.floor(volume)
-    tulpa_binary = number_to_bitstring(volume)
+    tulpa_binary = number_to_bitstring(volume, 16)
   end
 end
 


### PR DESCRIPTION
> At first, the numbers were drawn from numbered balls in a ball cage or three spins of a wheel of fortune. These methods could be manipulated and soon fell out of favor. Players wanted three numbers that were certified random. Bernstein’s game used the last three numbers of the United States Treasury Department balance which was printed daily in the business section of newspapers. When the Treasury Department began to round off their numbers—so they wouldn’t be a party to illegal gambling schemes—the three last digits of the number of shares traded on the New York Stock Exchange became the daily winning number. That number was found conveniently in the daily papers. 

-- [Gregory Fournier, "Detroit's Numbers Racket"](https://fornology.blogspot.com/2018/12/detroits-numbers-racket.html)